### PR TITLE
refactor: :recycle: event detail no longer use geocoding

### DIFF
--- a/lib/common/config/enum.dart
+++ b/lib/common/config/enum.dart
@@ -114,7 +114,12 @@ extension BadgeTierExtension on BadgeTier {
   }
 }
 
-enum DaysFilter { oneDay, oneWeek, twoWeeks, fourWeeks }
+enum DaysFilter {
+  oneDay,
+  oneWeek,
+  twoWeeks,
+  fourWeeks,
+}
 
 extension DaysFilterExtension on DaysFilter {
   String get desc {

--- a/lib/event/components/event_info.dart
+++ b/lib/event/components/event_info.dart
@@ -50,30 +50,36 @@ class EventInfo extends StatelessWidget {
           const SizedBox(
             width: 20,
           ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              !loading
-                  ? Text(
-                      title,
-                      style: const TextStyle(
-                          color: neutral,
-                          fontSize: CustomFontSize.base,
-                          fontWeight: FontWeight.bold),
-                    )
-                  : BuildLoading.buildRectangularLoading(
-                      height: 16, width: 100, verticalPadding: 3),
-              !loading
-                  ? Text(
-                      body,
-                      style: TextStyle(
-                          color: neutral.shade700,
-                          fontSize: CustomFontSize.lg,
-                          fontWeight: FontWeight.bold),
-                    )
-                  : BuildLoading.buildRectangularLoading(
-                      height: 18, width: 120, verticalPadding: 3)
-            ],
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                !loading
+                    ? Text(
+                        title,
+                        overflow: TextOverflow.fade,
+                        softWrap: false,
+                        style: const TextStyle(
+                            color: neutral,
+                            fontSize: CustomFontSize.base,
+                            fontWeight: FontWeight.bold),
+                      )
+                    : BuildLoading.buildRectangularLoading(
+                        height: 16, width: 100, verticalPadding: 3),
+                !loading
+                    ? Text(
+                        body,
+                        overflow: TextOverflow.fade,
+                        softWrap: false,
+                        style: TextStyle(
+                            color: neutral.shade700,
+                            fontSize: CustomFontSize.lg,
+                            fontWeight: FontWeight.bold),
+                      )
+                    : BuildLoading.buildRectangularLoading(
+                        height: 18, width: 120, verticalPadding: 3)
+              ],
+            ),
           )
         ],
       ),

--- a/lib/page/create_event.dart
+++ b/lib/page/create_event.dart
@@ -125,7 +125,7 @@ class _CreateEventFormState extends State<CreateEventForm> {
   final CustomFormInput shortDescription = CustomFormInput(
     label: 'Short Description',
     type: TextFieldType.textArea,
-    maxLength: 250,
+    maxLength: 100,
   );
   final CustomFormInput description = CustomFormInput(
     label: 'Description',
@@ -134,6 +134,7 @@ class _CreateEventFormState extends State<CreateEventForm> {
   final CustomFormInput location = CustomFormInput(
     label: 'Location',
     type: TextFieldType.location,
+    initialgoogleMapSuburb: "",
   );
 
   @override

--- a/lib/page/edit_event.dart
+++ b/lib/page/edit_event.dart
@@ -139,7 +139,7 @@ class _EditEventFormState extends State<EditEventForm> {
     final CustomFormInput shortDescription = CustomFormInput(
       label: 'Short Description',
       type: TextFieldType.textArea,
-      maxLength: 250,
+      maxLength: 100,
       initialValue: event?.shortDescription,
     );
     final CustomFormInput description = CustomFormInput(

--- a/lib/page/edit_profile.dart
+++ b/lib/page/edit_profile.dart
@@ -111,6 +111,7 @@ class _EditProfileState extends State<EditProfile> {
       label: "Location",
       type: TextFieldType.suburbDropdown,
       initialValue: user.location.suburb,
+      initialgoogleMapSuburb: "",
     );
     CustomFormInput isShareLocation = CustomFormInput(
       label: "Allow other users to see your location?",

--- a/lib/page/event_detail.dart
+++ b/lib/page/event_detail.dart
@@ -39,37 +39,6 @@ class EventDetail extends StatefulWidget {
 final googleApiKey = dotenv.env['googleApiKey'];
 
 class _EventDetailState extends State<EventDetail> {
-  geocode.GoogleGeocoding googleGeocoding =
-      geocode.GoogleGeocoding(googleApiKey!);
-
-  String locationName = "";
-  String locationArea = "";
-  String formattedAddress = "";
-  LoadingType geoCodeStatus = LoadingType.INITIAL;
-
-  Future<void> _handleReverseGeoCoding(double lat, double long) async {
-    try {
-      geocode.GeocodingResponse? response =
-          await googleGeocoding.geocoding.getReverse(geocode.LatLon(lat, long));
-      if (response != null) {
-        setState(() {
-          formattedAddress = response.results?[0].formattedAddress ?? "";
-          locationName =
-              response.results?[0].addressComponents?[0].longName ?? "";
-          locationArea =
-              '${response.results?[0].addressComponents?[1].longName ?? ""}, ${response.results?[0].addressComponents?[2].shortName}';
-          geoCodeStatus = LoadingType.SUCCESS;
-        });
-      }
-    } catch (e) {
-      setState(() {
-        locationName = "";
-        locationArea = "";
-        formattedAddress = "";
-      });
-    }
-  }
-
   @override
   Widget build(BuildContext buildContext) {
     return MultiBlocProvider(
@@ -104,12 +73,7 @@ class _EventDetailState extends State<EventDetail> {
               ),
               BlocListener<EventDetailCubit, EventDetailState>(
                 listener: (context, state) {
-                  // REVERSE GEO LOCATE HERE
-                  if (state.status == LoadingType.SUCCESS &&
-                      geoCodeStatus == LoadingType.INITIAL) {
-                    _handleReverseGeoCoding(state.model.event.latitude,
-                        state.model.event.longitude);
-                  } else if (state.status == LoadingType.ERROR) {
+                  if (state.status == LoadingType.ERROR) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         content: Text(state.message),
@@ -196,20 +160,17 @@ class _EventDetailState extends State<EventDetail> {
                             isSuccessState
                                 ? EventInfo(
                                     icon: Icons.location_on_outlined,
-                                    title: locationArea,
-                                    body: locationName,
+                                    title:
+                                        "${state.model.event.location.suburb}, ${state.model.event.location.city}",
+                                    body: state.model.event.locationName,
                                     onTap: () {
-                                      // OPEN GOOGLE MAP
-                                      if (geoCodeStatus ==
-                                          LoadingType.SUCCESS) {
-                                        Navigator.of(context).pushNamed(
-                                          ShowLocation.routeName,
-                                          arguments: PlaceModel(
-                                              formattedAddress,
-                                              state.model.event.latitude,
-                                              state.model.event.longitude),
-                                        );
-                                      }
+                                      Navigator.of(context).pushNamed(
+                                        ShowLocation.routeName,
+                                        arguments: PlaceModel(
+                                            state.model.event.locationName,
+                                            state.model.event.latitude,
+                                            state.model.event.longitude),
+                                      );
                                     },
                                   )
                                 : const EventInfo.loading(),

--- a/lib/page/homepage.dart
+++ b/lib/page/homepage.dart
@@ -158,29 +158,26 @@ class _BuildHomeState extends State<BuildHome> {
           height: 32,
         ),
         HomeContent(title: 'Categories', contentWidgets: [
-          Padding(
-            padding: const EdgeInsets.only(left: CustomPadding.body),
-            child: PreferenceButton(
-              type: PrefType.GM,
-              isAll: true,
-              elevation: 4.0,
-              onPressedHandler: () {
-                setState(() {
-                  if (clickCheck.contains(false)) {
-                    allCheck = !allCheck;
-                  }
-                });
-                if (!allCheck) {
-                  for (var category in categories) {
-                    clickCheck[category.index] = !clickCheck[category.index];
-                  }
-                  categories = [];
-                  categoriesData = [];
-                  getPopularEvents(context, categoriesData, radiusValue);
+          PreferenceButton(
+            type: PrefType.GM,
+            isAll: true,
+            elevation: 4.0,
+            onPressedHandler: () {
+              setState(() {
+                if (clickCheck.contains(false)) {
+                  allCheck = !allCheck;
                 }
-              },
-              click: allCheck,
-            ),
+              });
+              if (!allCheck) {
+                for (var category in categories) {
+                  clickCheck[category.index] = !clickCheck[category.index];
+                }
+                categories = [];
+                categoriesData = [];
+                getPopularEvents(context, categoriesData, radiusValue);
+              }
+            },
+            click: allCheck,
           ),
           for (var pref in PrefType.values)
             PreferenceButton(


### PR DESCRIPTION
### Background: 
- update event detail to no longer use geocoding
- remove paddings 

### Additional Packages/Dependencies:
-

### Changes:
- lib/common/config/enum.dart
- lib/event/components/event_info.dart
- lib/page/create_event.dart
- lib/page/edit_event.dart
- lib/page/edit_profile.dart
- lib/page/event_detail.dart
- lib/page/homepage.dart

### How to Implement:
-