### PR TITLE
feat: :sparkles: create empty state for popular events and search event

### DIFF
--- a/lib/event/components/event_list.dart
+++ b/lib/event/components/event_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter_boilerplate/common/config/enum.dart';
 import 'package:flutter_boilerplate/common/config/theme.dart';
 import 'package:flutter_boilerplate/event/components/event_card_small.dart';
 import 'package:flutter_boilerplate/event/components/home_content.dart';
+import 'package:flutter_boilerplate/event/components/no_events_card.dart';
 import 'package:flutter_boilerplate/event/data/event_by_user_model.dart';
 import 'package:intl/intl.dart';
 
@@ -31,26 +32,28 @@ class EventList extends StatelessWidget {
             fontSize: CustomFontSize.sm,
             type: TextButtonType.tertiary,
             onPressedHandler: onPressed),
-        contentWidgets: !isLoading
-            ? events.map((event) {
-                String formattedDate = DateFormat('MMMM dd, yyyy')
-                    .format(DateTime.parse(event.date));
-                List<String> splittedDate = formattedDate.split(' ');
-                return EventCardSmall(
-                    eventID: event.eventID,
-                    title: event.eventName,
-                    distance: event.distance,
-                    month: splittedDate[0].substring(0, 3),
-                    date: splittedDate[1].substring(0, 2),
-                    image: 'lib/common/assets/images/SmallEventTest.png');
-              }).toList()
-            : List.filled(
+        contentWidgets: isLoading
+            ? List.filled(
                 3,
                 const Padding(
                   padding: EdgeInsets.only(
                       left: CustomPadding.sm, top: CustomPadding.xs),
                   child: EventCardSmall.loading(),
                 ),
-              ));
+              )
+            : events.isEmpty
+                ? List.filled(1, const NoEventsCard())
+                : events.map((event) {
+                    String formattedDate = DateFormat('MMMM dd, yyyy')
+                        .format(DateTime.parse(event.date));
+                    List<String> splittedDate = formattedDate.split(' ');
+                    return EventCardSmall(
+                        eventID: event.eventID,
+                        title: event.eventName,
+                        distance: event.distance,
+                        month: splittedDate[0].substring(0, 3),
+                        date: splittedDate[1].substring(0, 2),
+                        image: 'lib/common/assets/images/SmallEventTest.png');
+                  }).toList());
   }
 }

--- a/lib/event/components/no_events_card.dart
+++ b/lib/event/components/no_events_card.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_boilerplate/common/config/theme.dart';
+
+class NoEventsCard extends StatelessWidget {
+  const NoEventsCard({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+          color: neutral.shade100,
+          borderRadius:
+              const BorderRadius.all(Radius.circular(CustomRadius.xxl)),
+          boxShadow: [
+            BoxShadow(
+              color: neutral.withOpacity(0.5),
+              spreadRadius: 1,
+              blurRadius: 1,
+            )
+          ]),
+      child: SizedBox(
+        width: 360,
+        height: 120,
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: CustomPadding.md,
+            bottom: CustomPadding.md,
+            left: CustomPadding.xxl,
+            right: CustomPadding.sm,
+          ),
+          child: Row(
+            children: [
+              Image.asset(
+                'lib/common/assets/images/NoResult.png',
+                width: 70,
+                height: 70,
+              ),
+              const SizedBox(
+                width: 25.0,
+              ),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Hmm, no sign of any events',
+                      style: TextStyle(
+                          fontSize: CustomFontSize.sm,
+                          fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(
+                      height: 3.0,
+                    ),
+                    Expanded(
+                      child: Text(
+                        "We couldnt find what you're looking for. Let's try something else.",
+                        style: TextStyle(
+                            fontSize: CustomFontSize.base,
+                            fontWeight: FontWeight.bold,
+                            color: neutral.shade300),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/page/search_events.dart
+++ b/lib/page/search_events.dart
@@ -9,6 +9,7 @@ import 'package:flutter_boilerplate/common/utils/debounce.dart';
 import 'package:flutter_boilerplate/event/bloc/search_event/search_event_cubit.dart';
 import 'package:flutter_boilerplate/event/bloc/search_event/search_event_state.dart';
 import 'package:flutter_boilerplate/event/components/event_card_large.dart';
+import 'package:flutter_boilerplate/event/components/no_events_Card.dart';
 import 'package:flutter_boilerplate/event/data/common/popular_event_model.dart';
 import 'package:flutter_boilerplate/event/data/search_event/filter_event_page_model.dart';
 import 'package:flutter_boilerplate/event/data/search_event/search_event_repository.dart';
@@ -165,59 +166,70 @@ class _BuildSearchEventsState extends State<BuildSearchEvents> {
               bool isSuccessState = state is SearchEventsSuccessState;
               bool isFetchMoreErrorState =
                   state is SearchEventsFetchMoreErrorState;
-              return Expanded(
+              bool isEventEmpty = false;
+              isSuccessState
+                  ? (state.events.isEmpty ? isEventEmpty = true : null)
+                  : null;
+              return Flexible(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: CustomPadding.body,
                   ),
                   child: SizedBox(
                     width: double.infinity,
-                    child: isSuccessState || isFetchMoreErrorState
-                        ? RefreshIndicator(
-                            onRefresh: (() async {
-                              context
-                                  .read<SearchEventsCubit>()
-                                  .searchEvents(filter);
-                            }),
-                            child: ListView.builder(
-                              padding: const EdgeInsets.only(
-                                  top: CustomPadding.base),
-                              itemCount: isSuccessState
-                                  ? state.events.length
-                                  : isFetchMoreErrorState
+                    child: isEventEmpty
+                        ? const FittedBox(
+                            child: Padding(
+                            padding: EdgeInsets.only(top: CustomPadding.base),
+                            child: NoEventsCard(),
+                          ))
+                        : isSuccessState || isFetchMoreErrorState
+                            ? RefreshIndicator(
+                                onRefresh: (() async {
+                                  context
+                                      .read<SearchEventsCubit>()
+                                      .searchEvents(filter);
+                                }),
+                                child: ListView.builder(
+                                  padding: const EdgeInsets.only(
+                                      top: CustomPadding.base),
+                                  itemCount: isSuccessState
                                       ? state.events.length
-                                      : 0,
-                              shrinkWrap: true,
-                              controller: _scrollController,
-                              itemBuilder: ((context, index) {
-                                return buildEvent(
-                                    context,
-                                    isSuccessState
-                                        ? state.events[index]
-                                        : isFetchMoreErrorState
+                                      : isFetchMoreErrorState
+                                          ? state.events.length
+                                          : 0,
+                                  shrinkWrap: true,
+                                  controller: _scrollController,
+                                  itemBuilder: ((context, index) {
+                                    return buildEvent(
+                                        context,
+                                        isSuccessState
                                             ? state.events[index]
-                                            : null);
-                              }),
-                            ),
-                          )
-                        : ListView(
-                            shrinkWrap: true,
-                            children: [
-                              Padding(
-                                padding: const EdgeInsets.only(
-                                    bottom: CustomPadding.xl),
-                                child:
-                                    EventCardLarge.loading(onTapHandler: () {}),
+                                            : isFetchMoreErrorState
+                                                ? state.events[index]
+                                                : null);
+                                  }),
+                                ),
+                              )
+                            : ListView(
+                                shrinkWrap: true,
+                                children: [
+                                  Padding(
+                                    padding: const EdgeInsets.only(
+                                        bottom: CustomPadding.xl,
+                                        top: CustomPadding.base),
+                                    child: EventCardLarge.loading(
+                                        onTapHandler: () {}),
+                                  ),
+                                  Padding(
+                                    padding: const EdgeInsets.only(
+                                        bottom: CustomPadding.xl),
+                                    child: EventCardLarge.loading(
+                                        onTapHandler: () {}),
+                                  ),
+                                  EventCardLarge.loading(onTapHandler: () {})
+                                ],
                               ),
-                              Padding(
-                                padding: const EdgeInsets.only(
-                                    bottom: CustomPadding.xl),
-                                child:
-                                    EventCardLarge.loading(onTapHandler: () {}),
-                              ),
-                              EventCardLarge.loading(onTapHandler: () {})
-                            ],
-                          ),
                   ),
                 ),
               );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -498,7 +498,7 @@ packages:
       name: image_picker_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.6"
+    version: "0.8.6+1"
   image_picker_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
### Background: 
- implement empty state for popular events in homepage and search event

### Additional Packages/Dependencies:
- none

### Changes:
- lib/event/components/event_list.dart
- lib/event/components/no_events_card.dart
- lib/page/search_events.dart
- pubspec.lock
